### PR TITLE
Clearer CFDs

### DIFF
--- a/app/views/jira_team_metrics/reports/delivery.html.erb
+++ b/app/views/jira_team_metrics/reports/delivery.html.erb
@@ -26,7 +26,7 @@
         3: { color: 'orange' }
       },
       chartArea: {
-        width: '95%',
+        width: '94%',
         height: '75%',
         top: 40
       },

--- a/lib/jira_team_metrics/version.rb
+++ b/lib/jira_team_metrics/version.rb
@@ -1,3 +1,3 @@
 module JiraTeamMetrics
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
* Truncate CFDs to just last two months of data
* Reduce width slightly to allow for 4 character shortened team names