### PR TITLE
Make predicted scope easier to understand

### DIFF
--- a/app/scope/jira_team_metrics/team_scope_report.rb
+++ b/app/scope/jira_team_metrics/team_scope_report.rb
@@ -154,7 +154,8 @@ private
   end
 
   def build_predicted_scope_for(epic)
-    if epic.issues(recursive: false).empty? && !@predicted_epic_scope.nil? && epic.status_category != 'Done'
+    issues_for_team = JiraTeamMetrics::TeamScopeReport.issues_for_team(epic.issues(recursive: false), @team)
+    if issues_for_team.empty? && !@predicted_epic_scope.nil? && epic.status_category != 'Done'
       @predicted_epic_scope.round.times do |k|
         @scope << JiraTeamMetrics::Issue.new({
           issue_type: 'Story',

--- a/app/views/jira_team_metrics/reports/project_scope.html.erb
+++ b/app/views/jira_team_metrics/reports/project_scope.html.erb
@@ -146,7 +146,11 @@
         <td>
           <%= issues.count %>
         </td>
-        <td></td>
+        <td>
+          <span class="ui <%= @domain.status_color_for(epic.status_category) %> label" style="width: 100%; text-align: center;">
+            <%= epic.status %>
+          </span>
+        </td>
       </tr>
 
       <% issues.each do |issue| %>
@@ -163,8 +167,10 @@
               <% end %>
             </td>
             <td></td>
-            <td class="<%= @domain.status_color_for(issue.status_category) %>">
-              <%= issue.status %>
+            <td>
+              <span class="ui <%= @domain.status_color_for(issue.status_category) %> label" style="width: 100%; text-align: center;">
+                <%= issue.status %>
+              </span>
             </td>
           </tr>
       <% end %>

--- a/lib/jira_team_metrics/version.rb
+++ b/lib/jira_team_metrics/version.rb
@@ -1,3 +1,3 @@
 module JiraTeamMetrics
-  VERSION = '0.23.1'
+  VERSION = '0.23.2'
 end


### PR DESCRIPTION
Currently if _any_ issues are in an epic, not predicted scope is added.

This change will add predicted scope of a team if they have not yet added their own scope.

It also shows epic statuses on the team scope page, so that it's easier to see why an epic may not have predicted scope (e.g. if it's been closed).