### PR TITLE
Fix team predictions

### DIFF
--- a/app/scope/jira_team_metrics/team_scope_report.rb
+++ b/app/scope/jira_team_metrics/team_scope_report.rb
@@ -154,6 +154,8 @@ private
   end
 
   def build_predicted_scope_for(epic)
+    return if @team == 'None'
+
     issues_for_team = JiraTeamMetrics::TeamScopeReport.issues_for_team(epic.issues(recursive: false), @team)
     if issues_for_team.empty? && !@predicted_epic_scope.nil? && epic.status_category != 'Done'
       @predicted_epic_scope.round.times do |k|

--- a/app/views/jira_team_metrics/reports/project_scope.html.erb
+++ b/app/views/jira_team_metrics/reports/project_scope.html.erb
@@ -147,9 +147,11 @@
           <%= issues.count %>
         </td>
         <td>
-          <span class="ui <%= @domain.status_color_for(epic.status_category) %> label" style="width: 100%; text-align: center;">
-            <%= epic.status %>
-          </span>
+          <% unless epic.nil? %>
+            <span class="ui <%= @domain.status_color_for(epic.status_category) %> label" style="width: 100%; text-align: center;">
+              <%= epic.status %>
+            </span>
+          <% end %>
         </td>
       </tr>
 

--- a/lib/jira_team_metrics/version.rb
+++ b/lib/jira_team_metrics/version.rb
@@ -1,3 +1,3 @@
 module JiraTeamMetrics
-  VERSION = '0.23.2'
+  VERSION = '0.23.3'
 end


### PR DESCRIPTION
1. Remove predicted scope for 'None' team.
2. Fix scope reports for teams with issues that aren't in epics.